### PR TITLE
Optimal alpha csv

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -13,6 +13,7 @@ METADATA_DIR = '%s/metadata' % DATA_DIR
 
 RESULTS_DIR = '%s/results' % DATA_DIR
 BEST_OF_BEST_DIR = '%s/gravitropism_results' % RESULTS_DIR
+EVALUATED_COSTS_DIR = '%s/gravitropism_pareto_fronts' % RESULTS_DIR #data/results/gravitropism_pareto_fronts
 
 PARETO_FRONTS_DIR = '%s/pareto-fronts' % RESULTS_DIR
 STATISTICS_DIR = '%s/statistics' % RESULTS_DIR

--- a/constants.py
+++ b/constants.py
@@ -13,7 +13,7 @@ METADATA_DIR = '%s/metadata' % DATA_DIR
 
 RESULTS_DIR = '%s/results' % DATA_DIR
 BEST_OF_BEST_DIR = '%s/gravitropism_results' % RESULTS_DIR
-EVALUATED_COSTS_DIR = '%s/gravitropism_pareto_fronts' % RESULTS_DIR #data/results/gravitropism_pareto_fronts
+EVALUATED_COSTS_DIR = '%s/heterogeneous_pareto_fronts' % RESULTS_DIR #data/results/heterogeneous_pareto_fronts
 
 PARETO_FRONTS_DIR = '%s/pareto-fronts' % RESULTS_DIR
 STATISTICS_DIR = '%s/statistics' % RESULTS_DIR

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -4,7 +4,7 @@ from constants import EVALUATED_COSTS_DIR
 from pathlib import Path
 
 # get all generated files in gravitropism_pareto_fronts
-def extract_optimal_dist_vals(fname):
+def extract_optimal_dist_vals(fname, name_len):
     '''
     Reads through a generated CSV in the gravitropism_pareto_fronts folder, which contains evaluated costs for 
     each arbor, and extracts information related to the minimum squared orthogonal distance in the file for each 
@@ -13,7 +13,6 @@ def extract_optimal_dist_vals(fname):
     '''
 
     # go through all CSVs in the gravitropism_pareto_fronts folder
-    #with open('%s/%s' % (EVALUATED_COSTS_DIR, fname)) as f:
     with open(fname) as f:
         arbor_csv = csv.reader(f)
         next(arbor_csv)
@@ -32,19 +31,17 @@ def extract_optimal_dist_vals(fname):
             cost_method = line[1]
             # checking if the current squared orthogonal distance is the smallest
             sq_orthog = float(line[-1].strip())
+            fname_str = str(fname)
 
             if cost_method == ' homogeneous':
                  if sq_orthog != 0 and sq_orthog < homog_opt_sq_orthog_dist:  # skipping the sq. orthogonal distance at the observed arbor values
-                    homog_opt_info = [fname, line[1], line[2], line[3], line[-1]] # extracting cost method, G, alpha, and sq. orthogonal distance
+                    homog_opt_info = [fname_str[name_len+1:], line[1], line[2], line[3], line[-1]] # extracting cost method, G, alpha, and sq. orthogonal distance
                     homog_opt_sq_orthog_dist = sq_orthog
             else:
                 if sq_orthog != 0 and sq_orthog < heterog_opt_sq_orthog_dist:
-                    heterog_opt_info = [fname, line[1], line[2], line[3], line[-1]]
+                    heterog_opt_info = [fname_str[name_len+1:], line[1], line[2], line[3], line[-1]]
                     heterog_opt_sq_orthog_dist = sq_orthog
             
-
-        #print(f"HOMOGENEOUS Info related to optimal orthog: {homog_opt_info}")
-        #print(f"HETEROGENEOUS Info related to optimal orthog: {heterog_opt_info}")
 
         return homog_opt_info, heterog_opt_info
 
@@ -55,11 +52,13 @@ def construct_CSV(arbor_folder):
         necessary information associated with the minimum sq. orthogonal distance into one CSV. 
         '''
         folder = Path(arbor_folder)
+        name_len = len(arbor_folder)
         csv_content = [["arbor", "cost method", "G", "alpha", "total squared orthogonal distance"]]
 
         # navigate through all files in the folder
         for arbor_file in folder.glob("*.csv"):
-            homog_opt_info, heterog_opt_info = extract_optimal_dist_vals(arbor_file)
+
+            homog_opt_info, heterog_opt_info = extract_optimal_dist_vals(arbor_file, name_len)
             csv_content.append(homog_opt_info)
             csv_content.append(heterog_opt_info)
         
@@ -72,6 +71,7 @@ def construct_CSV(arbor_folder):
 def main():
     print("Compiling all optimal heterogeneous/homogeneous alpha values...")
     construct_CSV(EVALUATED_COSTS_DIR)
+
     #construct_CSV("data/results/hetero_and_homogeneous")
     print("\nDone.")
 

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -1,0 +1,42 @@
+import sys
+from constants import EVALUATED_COSTS_DIR
+
+# get all generated files in gravitropism_pareto_fronts
+def extract_optimal_alpha_vals():
+    '''
+    Reads through all of the generated CSVs in the gravitropism_pareto_fronts folder, which contains evaluated costs for 
+    each arbor, and extracts them. All of these values will be organized into a new CSV file. 
+
+    '''
+
+    # go through all CSVs in the gravitropism_pareto_fronts folder
+    #with open('%s/%s' % (EVALUATED_COSTS_DIR, fname)) as f:
+    with open('data/results/gravitropism_pareto_fronts/pimpi_ABA_D9_set1_day9_20220610_RSA_M248M058LA1511_ABA_Salt003_M248_8_C_10aba.csv') as f:
+        csv_lines = []
+
+        for line in f:
+            line = line.strip('\n')
+            line = line.split(',')
+            csv_lines.append(line)
+        alpha_vals = [row[3] for row in csv_lines]
+        print(f"All lines: {csv_lines}\n")
+        print(f"Extracted values: {alpha_vals}")
+
+           
+
+    
+
+
+def main():
+    print("Compiling all optimal heterogeneous/homogeneous alpha values...")
+    extract_optimal_alpha_vals()
+
+
+if __name__ == '__main__':
+    
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Interrupted')
+        sys.exit(0)
+    

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -42,30 +42,48 @@ def extract_optimal_dist_vals(fname, name_len):
                     heterog_opt_info = [fname_str[name_len+1:], line[1], line[2], line[3], line[-1]]
                     heterog_opt_sq_orthog_dist = sq_orthog
             
+        # tracking difference between the alpha and squared orthogonal distances of both computation methods
+        print(f"this is homog_opt_info[3]: {homog_opt_info[3]}")
+        print(f"this is heterog_opt_info[3]: {heterog_opt_info[3]}")
 
-        return homog_opt_info, heterog_opt_info
+        alpha_diff = abs(float(homog_opt_info[3]) - float(heterog_opt_info[3]))
+        sq_orthog_dist_diff = abs(homog_opt_sq_orthog_dist - heterog_opt_sq_orthog_dist)
+
+        return homog_opt_info, heterog_opt_info, alpha_diff, sq_orthog_dist_diff
 
 
 def construct_CSV(arbor_folder):
         '''
         Navigates through all the CSV files in the gravitropism_pareto_fronts folder and compiles all the 
         necessary information associated with the minimum sq. orthogonal distance into one CSV. 
+
+        This function also creates a CSV file containing the differences between the alpha values and 
+        squared orthogonal distance of each computation method. 
         '''
         folder = Path(arbor_folder)
         name_len = len(arbor_folder)
         csv_content = [["arbor", "cost method", "G", "alpha", "total squared orthogonal distance"]]
+        diff_csv = [["arbor", "alpha difference", "squared orthogonal distance difference"]]
 
         # navigate through all files in the folder
-        for arbor_file in folder.glob("*.csv"):
+        #for arbor_file in folder.glob("*.csv"):
+        for i, arbor_file in enumerate(folder.glob("*.csv")):
+            if i >= 1000:
+                break
 
-            homog_opt_info, heterog_opt_info = extract_optimal_dist_vals(arbor_file, name_len)
+            homog_opt_info, heterog_opt_info, alpha_diff, sq_orthog_dist_diff = extract_optimal_dist_vals(arbor_file, name_len)
             csv_content.append(homog_opt_info)
             csv_content.append(heterog_opt_info)
+            diff_csv.append([homog_opt_info[0], alpha_diff, sq_orthog_dist_diff])
         
         # write all relevant info into the CSV
         with open("data/results/heterogeneous_results/optimal_distance_values.csv", "w", newline="") as csv_file:
             writer = csv.writer(csv_file)
             writer.writerows(csv_content)
+        
+        with open("data/results/heterogeneous_results/optimal_distance_values_diff.csv", "w", newline="") as csv_diff:
+            writer = csv.writer(csv_diff)
+            writer.writerows(diff_csv)
 
 
 def main():

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -43,33 +43,36 @@ def extract_optimal_dist_vals(fname):
                     heterog_opt_sq_orthog_dist = sq_orthog
             
 
-        print(f"HOMOGENEOUS Info related to optimal orthog: {homog_opt_info}")
-        print(f"HETEROGENEOUS Info related to optimal orthog: {heterog_opt_info}")
+        #print(f"HOMOGENEOUS Info related to optimal orthog: {homog_opt_info}")
+        #print(f"HETEROGENEOUS Info related to optimal orthog: {heterog_opt_info}")
 
         return homog_opt_info, heterog_opt_info
 
 
 def construct_CSV(arbor_folder):
+        '''
+        Navigates through all the CSV files in the gravitropism_pareto_fronts folder and compiles all the 
+        necessary information associated with the minimum sq. orthogonal distance into one CSV. 
+        '''
         folder = Path(arbor_folder)
         csv_content = [["arbor", "cost method", "G", "alpha", "total squared orthogonal distance"]]
 
+        # navigate through all files in the folder
         for arbor_file in folder.glob("*.csv"):
-            print(f"This is arbor file: {arbor_file}")
             homog_opt_info, heterog_opt_info = extract_optimal_dist_vals(arbor_file)
             csv_content.append(homog_opt_info)
             csv_content.append(heterog_opt_info)
         
-        print(csv_content)
-
-        with open("data/results/heterogeneous_results", "w", newline="") as csv_file:
+        # write all relevant info into the CSV
+        with open("data/results/heterogeneous_results/optimal_distance_values.csv", "w", newline="") as csv_file:
             writer = csv.writer(csv_file)
             writer.writerows(csv_content)
 
 
 def main():
-    print("Compiling all optimal heterogeneous/homogeneous alpha values...\n")
-    #construct_CSV(EVALUATED_COSTS_DIR)
-    construct_CSV("data/results/hetero_and_homogeneous")
+    print("Compiling all optimal heterogeneous/homogeneous alpha values...")
+    construct_CSV(EVALUATED_COSTS_DIR)
+    #construct_CSV("data/results/hetero_and_homogeneous")
     print("\nDone.")
 
 if __name__ == '__main__':

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -43,8 +43,6 @@ def extract_optimal_dist_vals(fname, name_len):
                     heterog_opt_sq_orthog_dist = sq_orthog
             
         # tracking difference between the alpha and squared orthogonal distances of both computation methods
-        #print(f"this is homog_opt_info[3]: {homog_opt_info[3]}")
-        #print(f"this is heterog_opt_info[3]: {heterog_opt_info[3]}")
 
         alpha_diff = abs(float(homog_opt_info[3]) - float(heterog_opt_info[3]))
         sq_orthog_dist_diff = abs(homog_opt_sq_orthog_dist - heterog_opt_sq_orthog_dist)
@@ -68,8 +66,6 @@ def construct_CSV(arbor_folder):
         # navigate through all files in the folder
         #for arbor_file in folder.glob("*.csv"):
         for i, arbor_file in enumerate(folder.glob("*.csv")):
-            #if i >= 1000:
-            #    break
             try:
                 homog_opt_info, heterog_opt_info, alpha_diff, sq_orthog_dist_diff = extract_optimal_dist_vals(arbor_file, name_len)
             except: 
@@ -92,8 +88,6 @@ def construct_CSV(arbor_folder):
 def main():
     print("Compiling all optimal heterogeneous/homogeneous alpha values...")
     construct_CSV(EVALUATED_COSTS_DIR)
-
-    #construct_CSV("data/results/hetero_and_homogeneous")
     print("\nDone.")
 
 if __name__ == '__main__':

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -1,63 +1,76 @@
 import sys
 import csv
 from constants import EVALUATED_COSTS_DIR
+from pathlib import Path
 
 # get all generated files in gravitropism_pareto_fronts
-def extract_optimal_alpha_vals():
+def extract_optimal_dist_vals(fname):
     '''
-    Reads through all of the generated CSVs in the gravitropism_pareto_fronts folder, which contains evaluated costs for 
-    each arbor, and extracts them. All of these values will be organized into a new CSV file. 
+    Reads through a generated CSV in the gravitropism_pareto_fronts folder, which contains evaluated costs for 
+    each arbor, and extracts information related to the minimum squared orthogonal distance in the file for each 
+    computation method.  
 
     '''
 
     # go through all CSVs in the gravitropism_pareto_fronts folder
     #with open('%s/%s' % (EVALUATED_COSTS_DIR, fname)) as f:
-    with open('data/results/gravitropism_pareto_fronts/pimpi_ABA_D9_set1_day9_20220610_RSA_M248M058LA1511_ABA_Salt003_M248_8_C_10aba.csv') as f:
+    with open(fname) as f:
         arbor_csv = csv.reader(f)
         next(arbor_csv)
         csv_lines = []
 
-        opt_info = []
-        opt_sq_orthog_dist = float('inf')
+        homog_opt_info = []
+        homog_opt_sq_orthog_dist = float('inf')
+
+        heterog_opt_info = []
+        heterog_opt_sq_orthog_dist = float('inf')
 
         for line in arbor_csv:
 
-            #line = line.strip('\n')
-            #line = line.split(',')
             csv_lines.append(line)
 
+            cost_method = line[1]
             # checking if the current squared orthogonal distance is the smallest
-        
-            print(f"this is sq_orthog: {line[-1].strip()}")
-            print(f"    and this is opt_sq_orthog_dist: {opt_sq_orthog_dist}")
             sq_orthog = float(line[-1].strip())
 
-            # skipping the sq. orthogonal distance at the observed arbor values
-            if sq_orthog != 0 and sq_orthog < opt_sq_orthog_dist:
-                    opt_info = line[0:-1] # 
-                    opt_sq_orthog_dist = sq_orthog
-            '''
-            try:
-                print(f"this is sq_orthog: {line[-1].strip()}")
-                sq_orthog = float(line[-1].strip())
+            if cost_method == ' homogeneous':
+                 if sq_orthog != 0 and sq_orthog < homog_opt_sq_orthog_dist:  # skipping the sq. orthogonal distance at the observed arbor values
+                    homog_opt_info = [fname, line[1], line[2], line[3], line[-1]] # extracting cost method, G, alpha, and sq. orthogonal distance
+                    homog_opt_sq_orthog_dist = sq_orthog
             else:
-                if sq_orthog != 0 and sq_orthog < opt_sq_orthog_dist:
-                    opt_info = line
-                    opt_sq_orthog_dist = line[-1]
-            '''
-        alpha_vals = [row[3] for row in csv_lines]
-        #print(f"All lines: {csv_lines}\n")
-        print(f"Extracted values: {alpha_vals}")
-        print(f"Optimal squared orthogonal distance: {opt_sq_orthog_dist}")
-        print(f"Info related to optimal orthog: {opt_info}")
+                if sq_orthog != 0 and sq_orthog < heterog_opt_sq_orthog_dist:
+                    heterog_opt_info = [fname, line[1], line[2], line[3], line[-1]]
+                    heterog_opt_sq_orthog_dist = sq_orthog
+            
 
+        print(f"HOMOGENEOUS Info related to optimal orthog: {homog_opt_info}")
+        print(f"HETEROGENEOUS Info related to optimal orthog: {heterog_opt_info}")
+
+        return homog_opt_info, heterog_opt_info
+
+
+def construct_CSV(arbor_folder):
+        folder = Path(arbor_folder)
+        csv_content = [["arbor", "cost method", "G", "alpha", "total squared orthogonal distance"]]
+
+        for arbor_file in folder.glob("*.csv"):
+            print(f"This is arbor file: {arbor_file}")
+            homog_opt_info, heterog_opt_info = extract_optimal_dist_vals(arbor_file)
+            csv_content.append(homog_opt_info)
+            csv_content.append(heterog_opt_info)
         
+        print(csv_content)
+
+        with open("data/results/heterogeneous_results", "w", newline="") as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerows(csv_content)
 
 
 def main():
-    print("Compiling all optimal heterogeneous/homogeneous alpha values...")
-    extract_optimal_alpha_vals()
-
+    print("Compiling all optimal heterogeneous/homogeneous alpha values...\n")
+    #construct_CSV(EVALUATED_COSTS_DIR)
+    construct_CSV("data/results/hetero_and_homogeneous")
+    print("\nDone.")
 
 if __name__ == '__main__':
     

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -43,8 +43,8 @@ def extract_optimal_dist_vals(fname, name_len):
                     heterog_opt_sq_orthog_dist = sq_orthog
             
         # tracking difference between the alpha and squared orthogonal distances of both computation methods
-        print(f"this is homog_opt_info[3]: {homog_opt_info[3]}")
-        print(f"this is heterog_opt_info[3]: {heterog_opt_info[3]}")
+        #print(f"this is homog_opt_info[3]: {homog_opt_info[3]}")
+        #print(f"this is heterog_opt_info[3]: {heterog_opt_info[3]}")
 
         alpha_diff = abs(float(homog_opt_info[3]) - float(heterog_opt_info[3]))
         sq_orthog_dist_diff = abs(homog_opt_sq_orthog_dist - heterog_opt_sq_orthog_dist)
@@ -68,10 +68,13 @@ def construct_CSV(arbor_folder):
         # navigate through all files in the folder
         #for arbor_file in folder.glob("*.csv"):
         for i, arbor_file in enumerate(folder.glob("*.csv")):
-            if i >= 1000:
+            #if i >= 1000:
+            #    break
+            try:
+                homog_opt_info, heterog_opt_info, alpha_diff, sq_orthog_dist_diff = extract_optimal_dist_vals(arbor_file, name_len)
+            except: 
+                print(f"Encountered an incomplete file ({arbor_file}), stopping.") # stopping entirely to prevent reading incomplete data
                 break
-
-            homog_opt_info, heterog_opt_info, alpha_diff, sq_orthog_dist_diff = extract_optimal_dist_vals(arbor_file, name_len)
             csv_content.append(homog_opt_info)
             csv_content.append(heterog_opt_info)
             diff_csv.append([homog_opt_info[0], alpha_diff, sq_orthog_dist_diff])

--- a/optimal_alpha_csv_gen.py
+++ b/optimal_alpha_csv_gen.py
@@ -1,4 +1,5 @@
 import sys
+import csv
 from constants import EVALUATED_COSTS_DIR
 
 # get all generated files in gravitropism_pareto_fronts
@@ -12,19 +13,45 @@ def extract_optimal_alpha_vals():
     # go through all CSVs in the gravitropism_pareto_fronts folder
     #with open('%s/%s' % (EVALUATED_COSTS_DIR, fname)) as f:
     with open('data/results/gravitropism_pareto_fronts/pimpi_ABA_D9_set1_day9_20220610_RSA_M248M058LA1511_ABA_Salt003_M248_8_C_10aba.csv') as f:
+        arbor_csv = csv.reader(f)
+        next(arbor_csv)
         csv_lines = []
 
-        for line in f:
-            line = line.strip('\n')
-            line = line.split(',')
+        opt_info = []
+        opt_sq_orthog_dist = float('inf')
+
+        for line in arbor_csv:
+
+            #line = line.strip('\n')
+            #line = line.split(',')
             csv_lines.append(line)
+
+            # checking if the current squared orthogonal distance is the smallest
+        
+            print(f"this is sq_orthog: {line[-1].strip()}")
+            print(f"    and this is opt_sq_orthog_dist: {opt_sq_orthog_dist}")
+            sq_orthog = float(line[-1].strip())
+
+            # skipping the sq. orthogonal distance at the observed arbor values
+            if sq_orthog != 0 and sq_orthog < opt_sq_orthog_dist:
+                    opt_info = line[0:-1] # 
+                    opt_sq_orthog_dist = sq_orthog
+            '''
+            try:
+                print(f"this is sq_orthog: {line[-1].strip()}")
+                sq_orthog = float(line[-1].strip())
+            else:
+                if sq_orthog != 0 and sq_orthog < opt_sq_orthog_dist:
+                    opt_info = line
+                    opt_sq_orthog_dist = line[-1]
+            '''
         alpha_vals = [row[3] for row in csv_lines]
-        print(f"All lines: {csv_lines}\n")
+        #print(f"All lines: {csv_lines}\n")
         print(f"Extracted values: {alpha_vals}")
+        print(f"Optimal squared orthogonal distance: {opt_sq_orthog_dist}")
+        print(f"Info related to optimal orthog: {opt_info}")
 
-           
-
-    
+        
 
 
 def main():


### PR DESCRIPTION
The script being added to the repository makes it possible to generate a CSV file that extracts information for the alpha value with the lowest squared orthogonal distance (for each computation method) from each arbor CSV file found in the gravitropism_pareto_fronts folder. It also creates a separate CSV file that contains the differences between the optimal alpha values and squared orthogonal distances for each arbor file. 

Everything can be found in the optimal_alpha_csv_gen.py file. 